### PR TITLE
Bugfix/broken install

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,27 +6,29 @@ A Python interface for the Quantum Exact Simulation Toolkit (QuEST) written main
 After cloning the repository
 
 ```console
-$ git clone -b develop --recursive https://github.com/rrmeister/pyQuEST
-$ cd pyQuEST
+$ git clone -b develop --recursive --shallow-submodules https://github.com/rrmeister/pyQuEST
 ```
 
-it is recommended to create a virtual environment, e.g. with `venv`.
+it is recommended to create a virtual environment, e.g. with `venv`, we'll call it `quantum-playground`.
 
 ```console
-$ python3 -m venv .
-$ source bin/activate
+$ python3 -m venv quantum-playground
+$ source quantum-playground/bin/activate
 ```
 
-To configure the QuEST backend for multithreading, GPU usage, float precision, etc., have a look at the QuEST build documentation.
+> By default, pyQuEST will use double precision for its floating point variables, have multithreading enabled, but GPU acceleration and distributed computing disabled. These settings can be changed in the dictionary `quest_config` at the top of `setup.py` *before* compiling and installing the package.
 
-The package can then be installed using pip.
+After setting the compile options as required, the package can be compiled and installed using `pip3`.
 
 ```console
-$ pip3 install .
+$ pip3 install ./pyQuEST
 ```
+
+> For this last step — depending on your system — you might have to separately install the Python development headers, usually called `python3-dev` or `python3-devel`. Check your distribution for details if the installer cannot find `Python.h`.
 
 ## Usage
-After successful installation, we can test pyQuEST by importing it and having a look at the environment it is running in.
+After successful installation, we can start a Python interpreter — with e.g. `ipython` or `python3` — and import pyQuEST to have a look at the environment it is running in.
+> Make sure to not launch your interpreter from within the `pyQuEST` folder, as the `pyquest` source directory would take precedence over the installed package and cause the import to fail.
 
 ```python
 In [1]: import pyquest
@@ -34,8 +36,7 @@ In [1]: import pyquest
 In [2]: pyquest.env
 Out[2]: QuESTEnvironment(cuda=False, openmp=False, mpi=False, num_threads=1, num_ranks=1, precision=2)
 ```
-
-The `QuESTEnvironment` class is automatically instantiated once upon module import and never needs to be called by the user. It contains internals and can return information about the execution environment, as above.
+The `QuESTEnvironment` class is automatically instantiated once upon module import and never needs to be called by the user. It contains internals and can return information about the execution environment, as above. If you changed the options in `setup.py`, make sure these are reflected in this output. If they are not, this indicates a problem during compiling.
 
 ### Example
 The most important classes are `Register` representing a quantum register, and the operators which can be applied to it. Let's create such a register with 3 qubits and look at its contents.

--- a/build_requirements.txt
+++ b/build_requirements.txt
@@ -1,4 +1,5 @@
 cmake==3.18.4.post1
-Cython==0.29.22
-numpy==1.20.1
+Cython==0.29.37
+numpy>=2.0.0
 scikit-build==0.11.1
+toml

--- a/build_requirements.txt
+++ b/build_requirements.txt
@@ -1,5 +1,5 @@
 cmake==3.18.4.post1
 Cython==0.29.37
-numpy>=2.0.0
+numpy>=1.20
 scikit-build==0.11.1
 toml

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-    requires = ['setuptools', 'wheel', 'toml', 'scikit-build', 'cmake>=3.18', 'cython==0.29.37', 'numpy>=2.0.0']
+    requires = ['setuptools', 'wheel', 'toml', 'scikit-build', 'cmake>=3.18', 'cython==0.29.37', 'numpy>=1.20']
     build-backend = 'setuptools.build_meta'  # Should be switched to skbuild-backend as soon as available.
 
 # This is not yet used by any backend tool, but we comply with PEP 621 and PEP 631 anyway. For now,
@@ -31,8 +31,8 @@
         "Programming Language :: Python :: 3 :: Only",
         "Topic :: Scientific/Engineering :: Physics",
     ]
-    requires-python = ">=3.12" # Try different python versions and find stable range
-    dependencies = ['numpy>=2.0.0']
+    requires-python = ">=3.8"
+    dependencies = ['numpy>=1.20']
 
     [project.urls]
     homepage = "https://github.com/rrmeister/pyQuEST"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-    requires = ['setuptools', 'wheel', 'toml', 'scikit-build', 'cmake>=3.13', 'cython==0.29.36', 'numpy>=1.20']
+    requires = ['setuptools', 'wheel', 'toml', 'scikit-build', 'cmake>=3.18', 'cython==0.29.37', 'numpy>=2.0.0']
     build-backend = 'setuptools.build_meta'  # Should be switched to skbuild-backend as soon as available.
 
 # This is not yet used by any backend tool, but we comply with PEP 621 and PEP 631 anyway. For now,
@@ -31,8 +31,8 @@
         "Programming Language :: Python :: 3 :: Only",
         "Topic :: Scientific/Engineering :: Physics",
     ]
-    requires-python = ">=3.7"
-    dependencies = ['numpy>=1.20']
+    requires-python = ">=3.12" # Try different python versions and find stable range
+    dependencies = ['numpy>=2.0.0']
 
     [project.urls]
     homepage = "https://github.com/rrmeister/pyQuEST"

--- a/pyquest/operators.pyx
+++ b/pyquest/operators.pyx
@@ -266,7 +266,8 @@ cdef class MatrixOperator(MultiQubitOperator):
         self.TYPE = OP_TYPES.OP_MATRIX
         if matrix is None:
             raise TypeError("Matrix representation must be given.")
-        cdef size_t matrix_dim = 2 ** self._num_targets
+        cdef size_t matrix_dim = 1  # Assigning a 1 first prevents integer overflows of the bit shift
+        matrix_dim = matrix_dim << self._num_targets
         if isinstance(matrix, np.ndarray):
             if matrix.ndim != 2:
                 raise ValueError("Array must have exactly 2 dimensions.")
@@ -302,7 +303,8 @@ cdef class MatrixOperator(MultiQubitOperator):
     def __repr__(self):
         res = type(self).__name__ + "(\n    " + str(self.targets) + ","
 
-        cdef size_t matrix_dim = 2 ** self._num_targets
+        cdef size_t matrix_dim = 1  # Assigning a 1 first prevents integer overflows of the bit shift
+        matrix_dim = matrix_dim << self._num_targets
         cdef size_t i, j
         res += "\n    array(\n        ["
         for i in range(matrix_dim):
@@ -317,7 +319,8 @@ cdef class MatrixOperator(MultiQubitOperator):
 
     @property
     def matrix(self):
-        cdef size_t mat_dim = 2**self._num_targets
+        cdef size_t mat_dim = 1
+        mat_dim = mat_dim << self._num_targets
         cdef size_t k, n
         cdef qcomp[:, :] np_mat = np.ndarray(
                 (mat_dim, mat_dim), dtype=pyquest.core.np_qcomp)
@@ -346,7 +349,8 @@ cdef class MatrixOperator(MultiQubitOperator):
                 self._num_targets, (<ComplexMatrixN*>self._matrix)[0])
 
     cdef _create_array_property(self):
-        cdef size_t matrix_dim = 2 ** self._num_targets
+        cdef size_t matrix_dim = 1  # Assigning a 1 first prevents integer overflows of the bit shift
+        matrix_dim = matrix_dim << self._num_targets
         cdef size_t k
         # The only cases where core QuEST supports ComplexMatrix2
         # or ComplexMatrix4 for generic matrices are non-controlled

--- a/pyquest/unitaries.pyx
+++ b/pyquest/unitaries.pyx
@@ -119,7 +119,8 @@ cdef class U(MatrixOperator):
         # We need to override this method, because core QuEST
         # supports ComplexMatrix* with controls for unitaries, but
         # not for generic matrices.
-        cdef size_t matrix_dim = 2 ** self._num_targets
+        cdef size_t matrix_dim = 1  # Assigning a 1 first prevents integer overflows of the bit shift
+        matrix_dim = matrix_dim << self._num_targets
         cdef size_t k
         if self._num_targets == 1:
             self._matrix = malloc(sizeof(ComplexMatrix2))


### PR DESCRIPTION
Resolves installation issues related to numpy 2.0.0 compatibility. The changes include:

1. Updated dependency specifications to ensure compatibility with numpy 2.0.0+
2. Added backward compatibility support for older Python (≥3.8) and numpy (≥1.20) versions
3. Modified matrix dimension calculation to use bit shift operations (<<) instead of power operator (**), preventing potential integer overflow issues in numpy 2.0
4. Synchronized readme content with master branch

These changes fix the binary incompatibility issues that were previously causing installation failures when using numpy 2.0.0 or higher. The solution maintains support for older versions (but no longer Python 3.7) while ensuring smooth installation with newer numpy releases.

Fixes #10 